### PR TITLE
Fix compilation error if #define USE_FAT 0

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -102,8 +102,9 @@ static const struct TextFile info[] = {
 // all directory entries must fit in a single sector
 // because otherwise current code overflows buffer
 #define DIRENTRIES_PER_SECTOR (512/sizeof(DirEntry))
+#if USE_FAT
 STATIC_ASSERT(NUM_DIRENTRIES < DIRENTRIES_PER_SECTOR * ROOT_DIR_SECTORS);
-
+#endif
 
 static const FAT_BootBlock BootBlock = {
     .JumpInstruction = {0xeb, 0x3c, 0x90},


### PR DESCRIPTION
NUM_DIRENTRIES is undefined if USE_FAT 0. I'm not quite sure why more of fat.c isn't excluded if USE_FAT 0, but this is the easy way to fix that one particular issue with minimal impact. Fix #51 