### PR TITLE
Change BOOTLOADER_BOARD_ID to be USB VID+PID

### DIFF
--- a/boards/arcade_feather_m4/board_config.h
+++ b/boards/arcade_feather_m4/board_config.h
@@ -90,7 +90,7 @@ const uint32_t config_data[] = {
     200, 0x1, // NUM_NEOPIXELS = 1
     204, 0x80000, // FLASH_BYTES = 0x80000
     205, 0x30000, // RAM_BYTES = 0x30000
-    208, 0x2b9e3d05, // BOOTLOADER_BOARD_ID = 0x2b9e3d05
+    208, 0x239a0022, // BOOTLOADER_BOARD_ID = 0x239a0022
     209, 0x55114460, // UF2_FAMILY = ATSAMD51
     210, 0x20, // PINS_PORT_SIZE = PA_32
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -101,6 +101,3 @@ const uint32_t config_data[] = {
 #endif
 
 #endif
-
-
-

--- a/boards/arcade_itsybitsy_m4/board_config.h
+++ b/boards/arcade_itsybitsy_m4/board_config.h
@@ -95,7 +95,7 @@ const uint32_t config_data[] = {
     201, 0x1, // NUM_DOTSTARS = 1
     204, 0x80000, // FLASH_BYTES = 0x80000
     205, 0x30000, // RAM_BYTES = 0x30000
-    208, 0x7a236324, // BOOTLOADER_BOARD_ID = 0x7a236324
+    208, 0x239a002b, // BOOTLOADER_BOARD_ID = 0x239a002b
     209, 0x55114460, // UF2_FAMILY = ATSAMD51
     210, 0x20, // PINS_PORT_SIZE = PA_32
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/boards/arcade_pybadge/board_config.h
+++ b/boards/arcade_pybadge/board_config.h
@@ -99,7 +99,7 @@ const uint32_t config_data[] = {
     200, 0x5, // NUM_NEOPIXELS = 5
     204, 0x80000, // FLASH_BYTES = 0x80000
     205, 0x30000, // RAM_BYTES = 0x30000
-    208, 0x75fdeb5f, // BOOTLOADER_BOARD_ID = 0x75fdeb5f
+    208, 0x239a0033, // BOOTLOADER_BOARD_ID = 0x239a0033
     209, 0x55114460, // UF2_FAMILY = ATSAMD51
     210, 0x20, // PINS_PORT_SIZE = PA_32
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -110,4 +110,3 @@ const uint32_t config_data[] = {
 #endif
 
 #endif
-

--- a/boards/arcade_pybadge_lc/board_config.h
+++ b/boards/arcade_pybadge_lc/board_config.h
@@ -95,7 +95,7 @@ const uint32_t config_data[] = {
     200, 0x1, // NUM_NEOPIXELS = 1
     204, 0x80000, // FLASH_BYTES = 0x80000
     205, 0x30000, // RAM_BYTES = 0x30000
-    208, 0x3f05ba69, // BOOTLOADER_BOARD_ID = 0x3f05ba69
+    208, 0x239a0034, // BOOTLOADER_BOARD_ID = 0x239a0034
     209, 0x55114460, // UF2_FAMILY = ATSAMD51
     210, 0x20, // PINS_PORT_SIZE = PA_32
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -106,4 +106,3 @@ const uint32_t config_data[] = {
 #endif
 
 #endif
-

--- a/boards/arcade_pygamer/board_config.h
+++ b/boards/arcade_pygamer/board_config.h
@@ -99,7 +99,7 @@ const uint32_t config_data[] = {
     200, 0x5, // NUM_NEOPIXELS = 5
     204, 0x80000, // FLASH_BYTES = 0x80000
     205, 0x30000, // RAM_BYTES = 0x30000
-    208, 0x2dd7a88c, // BOOTLOADER_BOARD_ID = 0x2dd7a88c
+    208, 0x239a003d, // BOOTLOADER_BOARD_ID = 0x239a003d
     209, 0x55114460, // UF2_FAMILY = ATSAMD51
     210, 0x20, // PINS_PORT_SIZE = PA_32
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -110,4 +110,3 @@ const uint32_t config_data[] = {
 #endif
 
 #endif
-


### PR DESCRIPTION
Use USB VID and PID to form `BOOTLOADER_BOARD_ID`, instead of a random number. This works for Adafruit boards, which generally have unique PID's. Tagging @mmoskal.

I'll make a new release, 3.7.0, and PR this to upstream once it's approved.