### PR TITLE
SAMD21 fixes

### DIFF
--- a/src/selfmain.c
+++ b/src/selfmain.c
@@ -11,124 +11,120 @@
 extern const uint8_t bootloader[];
 extern const uint16_t bootloader_crcs[];
 
-uint8_t pageBuf[FLASH_ROW_SIZE];
+uint8_t bootloader_page_buf[FLASH_ROW_SIZE];
 
 #if defined(SAMD21)
-#define NVM_FUSE_ADDR NVMCTRL_AUX0_ADDRESS
-#define exec_cmdaddr(cmd, addr)                                 \
-    do {                                                        \
-        NVMCTRL->STATUS.reg |= NVMCTRL_STATUS_MASK;             \
-        NVMCTRL->ADDR.reg = (uint32_t)addr / 2;                 \
-        NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | cmd;     \
-        while (NVMCTRL->INTFLAG.bit.READY == 0) {               \
-        }                                                       \
-    } while (0)
+#define NVM_FUSE_ADDR ((uint32_t *)NVMCTRL_AUX0_ADDRESS)
 #elif defined(SAMD51)
-#define NVM_FUSE_ADDR NVMCTRL_FUSES_BOOTPROT_ADDR
-#define exec_cmdaddr(cmd, addr)                                 \
-    do {                                                        \
-        NVMCTRL->ADDR.reg = (uint32_t)addr;                     \
-        NVMCTRL->CTRLB.reg = NVMCTRL_CTRLB_CMDEX_KEY | cmd;     \
-        while (NVMCTRL->STATUS.bit.READY == 0) {                \
-        }                                                       \
-    } while (0)
+#define NVM_FUSE_ADDR ((uint32_t *)NVMCTRL_FUSES_BOOTPROT_ADDR)
 #endif
-#define exec_cmd(cmd) exec_cmdaddr(cmd, NVMCTRL_USER)
 
-void setBootProt(int v) {
-    #if defined(SAMD21)
-        uint32_t fuses[2],
-                 newfuses[2];
-        while (!(NVMCTRL->INTFLAG.reg & NVMCTRL_INTFLAG_READY)) {
-        }
-    #elif defined(SAMD51)
-        uint32_t fuses[128],    // 512 bytes (whole user page)
-                 newfuses[5];
-        while (!NVMCTRL->STATUS.bit.READY) {
-        }
-    #endif
+static inline void nvmctrl_wait_ready(void) {
+#if defined(SAMD21)
+    while (NVMCTRL->INTFLAG.bit.READY == 0) { }
+#elif defined(SAMD51)
+    while (NVMCTRL->STATUS.bit.READY == 0) { }
+#endif
+}
+
+static inline void nvmctrl_set_addr(const uint32_t *addr) {
+#if defined(SAMD21)
+    NVMCTRL->ADDR.reg = (uint32_t)addr / 2;
+#elif defined(SAMD51)
+    NVMCTRL->ADDR.reg = (uint32_t)addr;
+#endif
+}
+
+static inline void nvmctrl_exec_cmd(uint32_t cmd) {
+#if defined(SAMD21)
+    NVMCTRL->STATUS.reg |= NVMCTRL_STATUS_MASK;  // Clear error status bits.
+    NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | cmd;
+    nvmctrl_wait_ready();
+#elif defined(SAMD51)
+    NVMCTRL->CTRLB.reg = NVMCTRL_CTRLB_CMDEX_KEY | cmd;
+#endif
+    nvmctrl_wait_ready();
+}
+
+void set_fuses_and_bootprot(uint32_t new_bootprot) {
+#if defined(SAMD21)
+    uint32_t fuses[2];
+#elif defined(SAMD51)
+    uint32_t fuses[128];    // 512 bytes (whole user page)
+#endif
+    nvmctrl_wait_ready();
 
     memcpy(fuses, (uint32_t *)NVM_FUSE_ADDR, sizeof(fuses));
-    memcpy(newfuses, fuses, sizeof(newfuses)); // Start with new values equal to current
 
-    // Check for damaged fuses. If the NVM user page was accidentally erased, there
-    // will be 1's in wrong places. This would enable the watchdog timer and cause other
-    // problems. So check for all ones outside of the SAMD21/51 BOOTPROT fields, or all ones
-    // in fuses[1]. If it appears the fuses page was erased, replace fuses with reasonable values.
-    bool repair_fuses = ((fuses[0] & 0x03fffff0) == 0x03fffff0 || fuses[1] == 0xffffffff);
-    #if defined(SAMD51)
-        // SAMD51 needs an additional check
-        repair_fuses |= (fuses[4] == 0xffffffff);
-    #endif
+    // If it appears the fuses page was erased (all ones), replace fuses with reasonable values.
+
+#if defined(SAMD21)
+    bool repair_fuses = (fuses[0] == 0xffffffff ||
+                         fuses[1] == 0xffffffff);
+#elif defined(SAMD51)
+    bool repair_fuses = (fuses[0] == 0xffffffff ||
+                         fuses[1] == 0xffffffff ||
+                         fuses[4] == 0xffffffff);
+#endif
+
     if (repair_fuses) {
         // These canonical fuse values taken from working Adafruit boards.
-        #if defined(SAMD21)
-            newfuses[0] = 0xD8E0C7FF;
-            newfuses[1] = 0xFFFFFC5D;
-        #elif defined(SAMD51)
-            newfuses[0] = 0xFE9A9239;
-            newfuses[1] = 0xAEECFF80;
-            newfuses[2] = 0xFFFFFFFF;
-            newfuses[4] = 0x00804010;
-        #endif
+        // BOOTPROT is set to nothing in these values.
+#if defined(SAMD21)
+        fuses[0] = 0xD8E0C7FF;
+        fuses[1] = 0xFFFFFC5D;
+#elif defined(SAMD51)
+        fuses[0] = 0xFE9A9239;
+        fuses[1] = 0xAEECFF80;
+        fuses[2] = 0xFFFFFFFF;
+        // fuses[3] is for user use, so we don't change it.
+        fuses[4] = 0x00804010;
+#endif
     }
 
-    uint32_t bootprot = (newfuses[0] & NVMCTRL_FUSES_BOOTPROT_Msk) >> NVMCTRL_FUSES_BOOTPROT_Pos;
+    uint32_t current_bootprot = (fuses[0] & NVMCTRL_FUSES_BOOTPROT_Msk) >> NVMCTRL_FUSES_BOOTPROT_Pos;
 
     logval("repair_fuses", repair_fuses);
-    logval("fuse0", newfuses[0]);
-    logval("fuse1", newfuses[1]);
-    #if defined(SAMD51)
-      logval("fuse2", newfuses[2]);
-      logval("fuse4", newfuses[4]);
-    #endif
-    logval("bootprot", bootprot);
-    logval("needed", v);
+    logval("current_bootprot", current_bootprot);
+    logval("new_bootprot", new_bootprot);
 
     // Don't write if nothing will be changed.
-    if (bootprot == v && !repair_fuses) {
+    if (current_bootprot == new_bootprot && !repair_fuses) {
         return;
     }
 
-    newfuses[0] = (newfuses[0] & ~NVMCTRL_FUSES_BOOTPROT_Msk) | (v << NVMCTRL_FUSES_BOOTPROT_Pos);
+    // Update fuses BOOTPROT value with desired value.
+    fuses[0] = (fuses[0] & ~NVMCTRL_FUSES_BOOTPROT_Msk) | (new_bootprot << NVMCTRL_FUSES_BOOTPROT_Pos);
 
-    bool format = false;
-    for (int i = 0; i < sizeof(newfuses) / sizeof(newfuses[0]); ++i)
-        format |= ((newfuses[i] ^ fuses[i]) & newfuses[i]);
-
-    memcpy(fuses, newfuses, sizeof(newfuses)); // Update page buffer with new fuses
-
-    #if defined(SAMD21)
-        NVMCTRL->CTRLB.reg = NVMCTRL->CTRLB.reg | NVMCTRL_CTRLB_CACHEDIS | NVMCTRL_CTRLB_MANW;
-
-        if (format) {
-            exec_cmd(NVMCTRL_CTRLA_CMD_EAR);
-        }
-        exec_cmd(NVMCTRL_CTRLA_CMD_PBC);
-    #elif defined(SAMD51)
-        NVMCTRL->CTRLA.bit.WMODE = NVMCTRL_CTRLA_WMODE_MAN;
-
-        if (format) {
-            exec_cmd(NVMCTRL_CTRLB_CMD_EP);
-        }
-        exec_cmd(NVMCTRL_CTRLB_CMD_PBC);
-    #endif
-
-    // 'endWriteIndex' is initialized with bytes that should be written.
-    // N.B. every itearation write a quadword, hence may be written more bytes than requested
-    const size_t endWriteIndex = format ? sizeof(fuses) : repair_fuses ? sizeof(newfuses) : 4;
+    // Write the fuses.
 
 #if defined(SAMD21)
-    uint32_t *const qwBlockAddr = (uint32_t *const)NVM_FUSE_ADDR;
-    memcpy(qwBlockAddr, fuses, endWriteIndex);
-    exec_cmdaddr(NVMCTRL_CTRLA_CMD_WAP, qwBlockAddr);
+    NVMCTRL->CTRLB.reg = NVMCTRL->CTRLB.reg | NVMCTRL_CTRLB_CACHEDIS | NVMCTRL_CTRLB_MANW;
+    nvmctrl_set_addr(NVM_FUSE_ADDR);  // Set address to auxiliary row (fuses).
+    nvmctrl_exec_cmd(NVMCTRL_CTRLA_CMD_EAR);  // Erase auxiliary row.
+    nvmctrl_exec_cmd(NVMCTRL_CTRLA_CMD_PBC);  // Clear page buffer (64 bytes).
+    // Writes must be 16 or 32 bits at a time.
+    NVM_FUSE_ADDR[0] = fuses[0];
+    NVM_FUSE_ADDR[1] = fuses[1];
+    nvmctrl_exec_cmd(NVMCTRL_CTRLA_CMD_WAP);
 #elif defined(SAMD51)
-    for (int i = 0; i < endWriteIndex; i += 16) {
-        uint32_t *const qwBlockAddr = (uint32_t *const)(NVM_FUSE_ADDR + i);
-        memcpy(qwBlockAddr, &fuses[i], 16);
-	exec_cmdaddr(NVMCTRL_CTRLB_CMD_WQW, qwBlockAddr);
+    NVMCTRL->CTRLA.bit.WMODE = NVMCTRL_CTRLA_WMODE_MAN;
+    nvmctrl_set_addr(NVM_FUSE_ADDR);  // Set address to user page.
+    nvmctrl_exec_cmd(NVMCTRL_CTRLB_CMD_EP);   // Erase user page.
+    nvmctrl_exec_cmd(NVMCTRL_CTRLB_CMD_PBC);  // Clear page buffer.
+    for (size_t i = 0; i < sizeof(fuses) / sizeof(uint32_t); i += 4) {
+        // Copy a quadword, one 32-bit word at a time. Writes to page
+        // buffer must be 16 or 32 bits at a time, so we use explicit
+        // word writes
+        NVM_FUSE_ADDR[i + 0] = fuses[i + 0];
+        NVM_FUSE_ADDR[i + 1] = fuses[i + 1];
+        NVM_FUSE_ADDR[i + 2] = fuses[i + 2];
+        NVM_FUSE_ADDR[i + 3] = fuses[i + 3];
+        nvmctrl_set_addr(&NVM_FUSE_ADDR[i]); // Set write address to the current quad word.
+	nvmctrl_exec_cmd(NVMCTRL_CTRLB_CMD_WQW); // Write quad word.
     }
 #endif
+
     resetIntoApp();
 }
 
@@ -150,26 +146,27 @@ int main(void) {
 
 #ifdef SAMD21
     // Disable BOOTPROT while updating bootloader.
-    setBootProt(7); // 0k - See "Table 22-2 Boot Loader Size" in datasheet.
+    set_fuses_and_bootprot(7); // 0k - See "Table 22-2 Boot Loader Size" in datasheet.
 #endif
 #ifdef SAMD51
+    // set_fuses_and_bootprot() will cause a reset and not return if
+    // the fuses are changed. We'll reenter main() and run this again,
+    // and it will do nothing the second time and fall hrough.
+    set_fuses_and_bootprot(13); // 16k. See "Table 25-10 Boot Loader Size" in datasheet.
+
     // We only need to set the BOOTPROT once on the SAMD51. For updates, we can
     // temporarily turn the protection off instead.
-    // setBootProt() will only write BOOTPROT if it is not already correct.
-    // setBootProt() will also fix the fuse values if they appear to be all ones.
-    setBootProt(13); // 16k. See "Table 25-10 Boot Loader Size" in datasheet.
-    exec_cmd(NVMCTRL_CTRLB_CMD_SBPDIS);
+    nvmctrl_exec_cmd(NVMCTRL_CTRLB_CMD_SBPDIS);
+    // Disable NVM caches, per errata.
     NVMCTRL->CTRLA.bit.CACHEDIS0 = true;
     NVMCTRL->CTRLA.bit.CACHEDIS1 = true;
 #endif
 
-    int i;
-
 #ifdef SAMD21
     const uint8_t *ptr = bootloader;
-    for (i = 0; i < BOOTLOADER_K; ++i) {
+    for (uint32_t i = 0; i < BOOTLOADER_K; ++i) {
         int crc = 0;
-        for (int j = 0; j < 1024; ++j) {
+        for (uint32_t j = 0; j < 1024; ++j) {
             crc = add_crc(*ptr++, crc);
         }
         if (bootloader_crcs[i] != crc) {
@@ -179,15 +176,15 @@ int main(void) {
     }
 #endif
 
-    for (i = 0; i < BOOTLOADER_K * 1024; i += FLASH_ROW_SIZE) {
-        memcpy(pageBuf, &bootloader[i], FLASH_ROW_SIZE);
-        flash_write_row((void *)i, (void *)pageBuf);
+    for (uint32_t i = 0; i < BOOTLOADER_K * 1024; i += FLASH_ROW_SIZE) {
+        memcpy(bootloader_page_buf, &bootloader[i], FLASH_ROW_SIZE);
+        flash_write_row((void *)i, (void *)bootloader_page_buf);
     }
 
     logmsg("Update successful!");
 
-    // re-base int vector back to bootloader, so that the flash erase below doesn't write over the
-    // vectors
+    // re-base int vector back to bootloader, so that the flash erase
+    // below doesn't write over the vectors.
     SCB->VTOR = 0;
 
     // Write zeros to the stack location and reset handler location so the
@@ -197,7 +194,7 @@ int main(void) {
     uint32_t zeros[2] = {0, 0};
     flash_write_words((void *)(BOOTLOADER_K * 1024), zeros, 2);
 
-    for (i = 0; i < 20; ++i) {
+    for (uint32_t i = 0; i < 8; ++i) {
         LED_MSC_TGL();
         delay(1000);
     }
@@ -206,13 +203,14 @@ int main(void) {
 
 #ifdef SAMD21
     // Re-enable BOOTPROT
-    setBootProt(2); // 8k
+    set_fuses_and_bootprot(2); // 8k
 #endif
     // For the SAMD51, the boot protection will automatically be re-enabled on
     // reset.
 
     resetIntoBootloader();
 
+    // We should not reach here normally.
     while (1) {
     }
 }


### PR DESCRIPTION
This does two things:
-- Fixes regression that arrived at some point in SAMD21 updater, which caused bricked boards. Fixes #112. Tagging @pelikhan.
-- Adds a mini fuse resetter to SAMD21 boards to fix fuses if first fuse word is set to all 1's, which causes continuous watchdog resets. Fixes #107.

I cleaned up the `selfmain.c` fuse-writing code a lot in the process of getting it to work again on SAMD21. Some trickery was removed. I would have liked to use this code for the SAMD21 fuse resetter mentioned above, but it was too big, so I used a stripped-down version. There are only 36 bytes free in the SAMD21 bootloader now.

Eventually a fuse resetter could be added to SAMD51 too, but right now there is enough time before the watchdog timer goes off to run the updater.

Next step after this is to merge in two new boards and make a 3.9.0 release.