### PR TITLE
added fix for baud samd21 vs samd51 due to different clock rates

### DIFF
--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -46,17 +46,17 @@
 // Check various conditions; best leave on
 #define USE_ASSERT 0 // 188 bytes
 // Enable reading flash via FAT files; otherwise drive will appear empty
-#define USE_FAT 1 // 272 bytes
+#define USE_FAT 0 // 272 bytes
 // Enable index.htm file on the drive
-#define USE_INDEX_HTM 1 // 132 bytes
+#define USE_INDEX_HTM 0 // 132 bytes
 // Enable USB CDC (Communication Device Class; i.e., USB serial) monitor for Arduino style flashing
 #define USE_CDC 1 // 1264 bytes (plus terminal, see below)
 // Support the UART (real serial port, not USB)
-#define USE_UART 0
+#define USE_UART 1
 // Support Human Interface Device (HID) - serial, flashing and debug
-#define USE_HID 1 // 788 bytes
+#define USE_HID 0 // 788 bytes
 // Expose HID via WebUSB
-#define USE_WEBUSB 1
+#define USE_WEBUSB 0
 // Doesn't yet disable code, just enumeration
 #define USE_MSC 1
 
@@ -74,9 +74,9 @@
 
 // Fine-tuning of features
 #define USE_HID_SERIAL 0   // just an example, not really needed; 36 bytes
-#define USE_HID_EXT 1      // extended HID commands (read/write mem); 60 bytes
-#define USE_HID_HANDOVER 1 // allow HID application->bootloader seamless transition; 56 bytes
-#define USE_MSC_HANDOVER 1 // ditto for MSC; 348 bytes
+#define USE_HID_EXT 0      // extended HID commands (read/write mem); 60 bytes
+#define USE_HID_HANDOVER 0 // allow HID application->bootloader seamless transition; 56 bytes
+#define USE_MSC_HANDOVER 0 // ditto for MSC; 348 bytes
 #define USE_MSC_CHECKS 0   // check validity of MSC commands; 460 bytes
 #define USE_CDC_TERMINAL 0 // enable ASCII mode on CDC loop (not used by BOSSA); 228 bytes
 #define USE_DBG_MSC 0      // output debug info about MSC


### PR DESCRIPTION
3 bugs fixed. Only tested on samd51

1: Fix for baud samd21 vs samd51
2: Added fix for first run where super slow first run of crc would cause
overruns on USART.
3: Prevent GCC from optimizing out a busy wait loop in Xmodem code
 
Only usart_sam_ba.c
 The  change uf2.h is the config for my test. I do not know how to not have that part show.

