### PR TITLE
Add ability to configure wait states with defines

### DIFF
--- a/inc/main.h
+++ b/inc/main.h
@@ -32,7 +32,9 @@
 
 #define CPU_FREQUENCY 48000000
 
+#ifndef FLASH_WAIT_STATES //allow for other wait states 
 #define FLASH_WAIT_STATES 1
+#endif
 
 #ifndef BOOT_USART_MODULE
 #define BOOT_USART_MODULE SERCOM3

--- a/src/init_samd21.c
+++ b/src/init_samd21.c
@@ -26,7 +26,7 @@ static void dfll_sync(void) {
 
 void system_init(void) {
 
-  NVMCTRL->CTRLB.bit.RWS = 1;
+    NVMCTRL->CTRLB.bit.RWS = FLASH_WAIT_STATES;
 
 #if defined(CRYSTALLESS)
   /* Configure OSC8M as source for GCLK_GEN 2 */

--- a/src/init_samd51.c
+++ b/src/init_samd51.c
@@ -5,7 +5,7 @@ uint32_t current_cpu_frequency_MHz = 48;
 
 void system_init(void) {
     // Automatic wait states.
-    NVMCTRL->CTRLA.bit.AUTOWS = 1;
+    NVMCTRL->CTRLA.bit.AUTOWS = FLASH_WAIT_STATES;
 
     // Output GCLK0 to Metro M4 D5. This way we can see if/when we mess it up.
     // PORT->Group[1].PINCFG[14].bit.PMUXEN = true;


### PR DESCRIPTION
Adds ability to set wait states in the board.h files for devices that use voltages below 2.7v or clocks below 48mhz. I am developing a few boards that use SAMD21 at 2.5v and 1.8v and 1 wait state at 48mhz leads to invalid reads, this allows one to configure that in the board.h instead.