### PR TITLE
Correct OSC8M clock setup

### DIFF
--- a/src/init_samd21.c
+++ b/src/init_samd21.c
@@ -33,7 +33,7 @@ void system_init(void) {
   GCLK->GENDIV.reg = GCLK_GENDIV_ID(2);  // Read GENERATOR_ID - GCLK_GEN_2
   gclk_sync();
 
-  GCLK->GENCTRL.reg = GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_SRC_OSC8M_Val | GCLK_GENCTRL_GENEN;
+  GCLK->GENCTRL.reg = GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_SRC_OSC8M | GCLK_GENCTRL_GENEN;
   gclk_sync();
 
   // Turn on DFLL with USB correction and sync to internal 8 mhz oscillator


### PR DESCRIPTION
As discussed in issue #179 - Changes OSC8M clock setup to us the bit-shifted GCLK_GENCTRL_SRC_OSC8M #define rather than the GCLK_GENCTRL_SRC_OSC8M_Val #define.