### PR TITLE
Clock fixes

### DIFF
--- a/src/init_samd21.c
+++ b/src/init_samd21.c
@@ -29,13 +29,6 @@ void system_init(void) {
   NVMCTRL->CTRLB.bit.RWS = 1;
 
 #if defined(CRYSTALLESS)
-  /* Configure OSC8M as source for GCLK_GEN 2 */
-  GCLK->GENDIV.reg = GCLK_GENDIV_ID(2);  // Read GENERATOR_ID - GCLK_GEN_2
-  gclk_sync();
-
-  GCLK->GENCTRL.reg = GCLK_GENCTRL_ID(2) | GCLK_GENCTRL_SRC_OSC8M_Val | GCLK_GENCTRL_GENEN;
-  gclk_sync();
-
   // Turn on DFLL with USB correction and sync to internal 8 mhz oscillator
   SYSCTRL->DFLLCTRL.reg = SYSCTRL_DFLLCTRL_ENABLE;
   dfll_sync();

--- a/src/init_samd21.c
+++ b/src/init_samd21.c
@@ -60,15 +60,6 @@ void system_init(void) {
   SYSCTRL->DFLLCTRL.reg |= SYSCTRL_DFLLCTRL_ENABLE ;
   dfll_sync();
 
-  GCLK_CLKCTRL_Type clkctrl={0};
-  uint16_t temp;
-  GCLK->CLKCTRL.bit.ID = 2; // GCLK_ID - DFLL48M Reference
-  temp = GCLK->CLKCTRL.reg;
-  clkctrl.bit.CLKEN = 1;
-  clkctrl.bit.WRTLOCK = 0;
-  clkctrl.bit.GEN = GCLK_CLKCTRL_GEN_GCLK0_Val;
-  GCLK->CLKCTRL.reg = (clkctrl.reg | temp);
-
 #else
 
     SYSCTRL->XOSC32K.reg =

--- a/src/main.c
+++ b/src/main.c
@@ -56,11 +56,18 @@
  *
  * Clock system
  * --------------------
- * CPU clock source (GCLK_GEN_0) - 8MHz internal oscillator (OSC8M)
- * SERCOM5 core GCLK source (GCLK_ID_SERCOM5_CORE) - GCLK_GEN_0 (i.e., OSC8M)
- * GCLK Generator 1 source (GCLK_GEN_1) - 48MHz DFLL in Clock Recovery mode
+ * CPU clock source (GCLK_GEN_0) - 48MHz DFLL oscillator (DFLL48M)
+ * SERCOM5 core GCLK source (GCLK_ID_SERCOM5_CORE) - GCLK_GEN_0 (i.e., FDLL48M)
+ * USB GCLK source (GCLK_ID_USB) - GCLK_GEN_0 (i.e., DFLL in CRM or open loop mode)
+ *
+ * Crystalless mode:
+ * GCLK Generator 0 source (GCLK_GEN_0) - 48MHz DFLL in Clock Recovery mode
  * (DFLL48M)
- * USB GCLK source (GCLK_ID_USB) - GCLK_GEN_1 (i.e., DFLL in CRM mode)
+ *
+ * Crytal mode:
+ * GCLK Generator 0 source (GCLK_GEN_0) - 48MHz DFLL in closed loop mode
+ * GCLK Generator 1 source (GCLK_GEN_1) - 32 kHz external cyrstal (XOSC32K)
+ * DFLL48M Refence clock (GCLK_DFLL48M_REF) - GCLK_GEN_1 (i.e., XOSC32K)
  *
  * Memory Mapping
  * --------------------

--- a/src/usart_sam_ba.c
+++ b/src/usart_sam_ba.c
@@ -115,8 +115,8 @@ void usart_open() {
     clkctrl.bit.WRTLOCK = false;
     clkctrl.bit.GEN = GCLK_CLKCTRL_GEN_GCLK0_Val;
     GCLK->CLKCTRL.reg = (clkctrl.reg | temp);
-    /* Baud rate 115200 - clock 8MHz -> BAUD value-50436 */
-    uart_basic_init(BOOT_USART_MODULE, 50436, BOOT_USART_PAD_SETTINGS);
+    /* Baud rate 115200 - clock 48MHz -> BAUD value-63018 */
+    uart_basic_init(BOOT_USART_MODULE, 63018, BOOT_USART_PAD_SETTINGS);
     #endif
 
     #ifdef SAMD51


### PR DESCRIPTION
There are several errors in the clock setup.
* GLCK2 isn't configured because of an incorrect macro, instead it configures GCLK6.  Neither is necessary.
* The FDPLL is given an incorrect reference clock. It is not used and does not need a reference.
* SAMD21 UART has incorrect baud rate.
* Comment about clock setup are wrong.

Read individual commit messages for more details.