### PR TITLE
change default USB power down to 100mA

### DIFF
--- a/src/cdc_enumerate.c
+++ b/src/cdc_enumerate.c
@@ -106,7 +106,7 @@ const char hidDescriptor[] = {
 #endif
 
 #ifndef USB_POWER_MA
-#define USB_POWER_MA 500
+#define USB_POWER_MA 100
 #endif
 __attribute__((__aligned__(4)))
 char cfgDescriptor[] = {


### PR DESCRIPTION
Since a device in bootloader mode shouldn't be powering any external peripherals, a 100mA default power level is more sensible than 500mA and may give better compatibility e.g., in USB OTG settings