### PR TITLE
Enable BOD33 protection for SAMD21

### DIFF
--- a/src/selfmain.c
+++ b/src/selfmain.c
@@ -194,13 +194,6 @@ int main(void) {
     uint32_t zeros[2] = {0, 0};
     flash_write_words((void *)(BOOTLOADER_K * 1024), zeros, 2);
 
-    for (uint32_t i = 0; i < 8; ++i) {
-        LED_MSC_TGL();
-        delay(1000);
-    }
-
-    LED_MSC_OFF();
-
 #ifdef SAMD21
     // Re-enable BOOTPROT
     set_fuses_and_bootprot(2); // 8k
@@ -208,6 +201,7 @@ int main(void) {
     // For the SAMD51, the boot protection will automatically be re-enabled on
     // reset.
 
+    LED_MSC_OFF();
     resetIntoBootloader();
 
     // We should not reach here normally.


### PR DESCRIPTION
- Enable BOD33 on SAMD21. Set brownout voltage to about 2.85V.
- Remove 8 second delay before restarting in `selfmain.c `(update-bootloader). This was confusing on boards without an LED: users might reset the board before the BOOTPROT was set properly. Tested without delay on Windows, macOS, and Linux in case there was some remounting problem.

Original support thread about this: https://forums.adafruit.com/viewtopic.php?t=198035