### PR TITLE
Update cdc_enumerate.c

### DIFF
--- a/src/cdc_enumerate.c
+++ b/src/cdc_enumerate.c
@@ -721,7 +721,7 @@ uint32_t USB_WriteCore(const void *pData, uint32_t length, uint8_t ep_num, bool 
 //* \brief Send zero length packet through the control endpoint
 //*----------------------------------------------------------------------------
 void AT91F_USB_SendZlp(void) {
-    uint8_t c;
+    uint8_t c = 0;
     USB_Write(&c, 0, 0);
 }
 


### PR DESCRIPTION
'c' should be initialized to 0, throws  warning (treated like an error) otherwise.