### PR TITLE
do not leave dotstar on after exiting bootloader

### DIFF
--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -153,7 +153,7 @@
 #define COLOR_START 0x000040
 #define COLOR_USB 0x004000
 #define COLOR_UART 0x404000
-#define COLOR_LEAVE 0x400040
+#define COLOR_LEAVE 0x000000
 #endif
 
 /*


### PR DESCRIPTION
The NeoPixels are correctly turned off before exiting the bootloader but the DotStar is left in bright purple for some reason. Observable on Trinket M0.