### PR TITLE
ensure BOD33 remains running in standby

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -250,6 +250,7 @@ int main(void) {
     SUPC->BOD33.bit.LEVEL = 200;  // 2.7V: 1.5V + LEVEL * 6mV.
     // Don't reset right now.
     SUPC->BOD33.bit.ACTION = SUPC_BOD33_ACTION_NONE_Val;
+    SUPC->BOD33.bit.RUNSTDBY = 1;
     SUPC->BOD33.bit.ENABLE = 1; // enable brown-out detection
 
     // Wait for BOD33 peripheral to be ready.


### PR DESCRIPTION
enabling RUNSTDBY later in sketch code requires the BOD33 to be disabled and then re-enabled. given the possibility of flash corruption while it is disabled, we want to do this as few times as possible