### PR TITLE
Fix error response for invalid/unimplemented MSC commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         filter: "blob:none"
@@ -25,7 +25,7 @@ jobs:
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
         # When changing this update what Windows grabs too!
-        release: '13.2.Rel1'    
+        release: '14.3.Rel1'
     - name: Extract version identifier
       run: |
         echo >> $GITHUB_ENV "UF2_VERSION_BASE=`git describe --dirty --always --tags`"
@@ -33,6 +33,6 @@ jobs:
       run: make submodules && make -j$(nproc) all-boards && mv build/drop build/uf2-samdx1-$UF2_VERSION_BASE
     - name: Upload artifact
       uses: actions/upload-artifact@v4
-      with: 
+      with:
         path: build/uf2-samdx1-${{ env.UF2_VERSION_BASE }}/*
         name: uf2-samdx1-${{ env.UF2_VERSION_BASE }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 BOARD=zero
+
+ifeq ($(VERBOSE), 1)
+Q=
+else
+Q=@
+endif
+
 -include Makefile.user
 include boards/$(BOARD)/board.mk
 CC=arm-none-eabi-gcc
@@ -19,19 +26,22 @@ WFLAGS = \
 -Wno-deprecated-declarations -Wpacked -Wredundant-decls -Wnested-externs \
 -Wlong-long -Wunreachable-code -Wcast-align \
 -Wno-missing-braces -Wno-overflow -Wno-shadow -Wno-attributes -Wno-packed -Wno-pointer-sign
+
 CFLAGS = $(COMMON_FLAGS) \
 -x c -c -pipe -nostdlib \
---param max-inline-insns-single=500 \
 -fno-strict-aliasing -fdata-sections -ffunction-sections \
 -D__$(CHIP_VARIANT)__ \
 $(WFLAGS)
 
-UF2_VERSION_BASE = $(shell git describe --dirty --always --tags)
+# Use "+" instead of "-dirty" to save a few bytes.
+UF2_VERSION_BASE = $(shell git describe --dirty=+ --always --tags)
 
 ifeq ($(CHIP_FAMILY), samd21)
 LINKER_SCRIPT=scripts/samd21j18a.ld
 BOOTLOADER_SIZE=8192
 SELF_LINKER_SCRIPT=scripts/samd21j18a_self.ld
+# Code squeezing.
+CFLAGS += -fno-jump-tables
 endif
 
 ifeq ($(CHIP_FAMILY), samd51)
@@ -155,37 +165,37 @@ selflogs:
 	node scripts/dbgtool.js $(BUILD_PATH)/update-$(NAME).map
 
 dirs:
-	@echo "Building $(BOARD)"
+	@echo
+	@echo "--- Building $(BOARD) ---"
 	-@mkdir -p $(BUILD_PATH)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) -L$(BUILD_PATH) $(LDFLAGS) \
+	$(Q)$(CC) -L$(BUILD_PATH) $(LDFLAGS) \
 		 -T$(LINKER_SCRIPT) \
 		 -Wl,-Map,$(BUILD_PATH)/$(NAME).map -o $(BUILD_PATH)/$(NAME).elf $(OBJECTS)
-	arm-none-eabi-objcopy -O binary $(BUILD_PATH)/$(NAME).elf $@
-	@echo
+	$(Q)arm-none-eabi-objcopy -O binary $(BUILD_PATH)/$(NAME).elf $@
+	$(Q)@echo
 	-@arm-none-eabi-size $(BUILD_PATH)/$(NAME).elf | awk '{ s=$$1+$$2; print } END { print ""; print "Space left: " ($(BOOTLOADER_SIZE)-s) }'
-	@echo
+	$(Q)@echo
 
-$(BUILD_PATH)/uf2_version.h: Makefile
-	echo "#define UF2_VERSION_BASE \"$(UF2_VERSION_BASE)\""> $@
+$(BUILD_PATH)/uf2_version.h: Makefile dirs
+	@echo "#define UF2_VERSION_BASE \"$(UF2_VERSION_BASE)\""> $@
 
 $(SELF_EXECUTABLE): $(SELF_OBJECTS)
-	$(CC) -L$(BUILD_PATH) $(LDFLAGS) \
+	$(Q)$(CC) -L$(BUILD_PATH) $(LDFLAGS) \
 		 -T$(SELF_LINKER_SCRIPT) \
 		 -Wl,-Map,$(BUILD_PATH)/update-$(NAME).map -o $(BUILD_PATH)/update-$(NAME).elf $(SELF_OBJECTS)
-	arm-none-eabi-objcopy -O binary $(BUILD_PATH)/update-$(NAME).elf $(BUILD_PATH)/update-$(NAME).bin
-	python3 lib/uf2/utils/uf2conv.py -b $(BOOTLOADER_SIZE) -c -o $@ $(BUILD_PATH)/update-$(NAME).bin
+	$(Q)arm-none-eabi-objcopy -O binary $(BUILD_PATH)/update-$(NAME).elf $(BUILD_PATH)/update-$(NAME).bin
+	$(Q)python3 lib/uf2/utils/uf2conv.py -b $(BOOTLOADER_SIZE) -c -o $@ $(BUILD_PATH)/update-$(NAME).bin
 
 $(BUILD_PATH)/%.o: src/%.c $(wildcard inc/*.h boards/*/*.h) $(BUILD_PATH)/uf2_version.h
-	echo "$<"
-	$(CC) $(CFLAGS) $(BLD_EXTA_FLAGS) $(INCLUDES) $< -o $@
+	$(Q)$(CC) $(CFLAGS) $(BLD_EXTA_FLAGS) $(INCLUDES) $< -o $@
 
 $(BUILD_PATH)/%.o: $(BUILD_PATH)/%.c
-	$(CC) $(CFLAGS) $(BLD_EXTA_FLAGS) $(INCLUDES) $< -o $@
+	$(Q)$(CC) $(CFLAGS) $(BLD_EXTA_FLAGS) $(INCLUDES) $< -o $@
 
 $(BUILD_PATH)/selfdata.c: $(EXECUTABLE) scripts/gendata.py src/sketch.cpp
-	python3 scripts/gendata.py $(BOOTLOADER_SIZE) $(EXECUTABLE)
+	$(Q)python3 scripts/gendata.py $(BOOTLOADER_SIZE) $(EXECUTABLE)
 
 clean:
 	rm -rf build
@@ -206,16 +216,15 @@ applet1: $(BUILD_PATH)/utils.asmdump
 	node scripts/genapplet.js $< resetIntoApp
 
 drop-board: all
-	@echo "*** Copy files for $(BOARD)"
-	mkdir -p build/drop
-	rm -rf build/drop/$(BOARD)
-	mkdir -p build/drop/$(BOARD)
-	cp $(SELF_EXECUTABLE) build/drop/$(BOARD)/
-	cp $(EXECUTABLE) build/drop/$(BOARD)/
+	@mkdir -p build/drop
+	@rm -rf build/drop/$(BOARD)
+	@mkdir -p build/drop/$(BOARD)
+	@cp $(SELF_EXECUTABLE) build/drop/$(BOARD)/
+	@cp $(EXECUTABLE) build/drop/$(BOARD)/
 # .ino works only for SAMD21 right now; suppress for SAMD51
 ifeq ($(CHIP_FAMILY),samd21)
-	cp $(SELF_EXECUTABLE_INO) build/drop/$(BOARD)/
-	cp boards/$(BOARD)/board_config.h build/drop/$(BOARD)/
+	@cp $(SELF_EXECUTABLE_INO) build/drop/$(BOARD)/
+	@cp boards/$(BOARD)/board_config.h build/drop/$(BOARD)/
 endif
 
 drop-pkg:
@@ -225,7 +234,7 @@ drop-pkg:
 	rm -rf build/uf2-samdx1-$(UF2_VERSION_BASE)
 
 all-boards:
-	for f in `cd boards; ls` ; do "$(MAKE)" BOARD=$$f drop-board || break -1; done
+	$(Q)@for f in `cd boards; ls` ; do "$(MAKE)" --no-print-directory BOARD=$$f drop-board || break 1; done
 
 drop: all-boards drop-pkg
 

--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,9 @@ $(EXECUTABLE): $(OBJECTS)
 		 -T$(LINKER_SCRIPT) \
 		 -Wl,-Map,$(BUILD_PATH)/$(NAME).map -o $(BUILD_PATH)/$(NAME).elf $(OBJECTS)
 	$(Q)arm-none-eabi-objcopy -O binary $(BUILD_PATH)/$(NAME).elf $@
-	$(Q)@echo
+	@echo
 	-@arm-none-eabi-size $(BUILD_PATH)/$(NAME).elf | awk '{ s=$$1+$$2; print } END { print ""; print "Space left: " ($(BOOTLOADER_SIZE)-s) }'
-	$(Q)@echo
+	@echo
 
 $(BUILD_PATH)/uf2_version.h: Makefile dirs
 	@echo "#define UF2_VERSION_BASE \"$(UF2_VERSION_BASE)\""> $@
@@ -234,7 +234,7 @@ drop-pkg:
 	rm -rf build/uf2-samdx1-$(UF2_VERSION_BASE)
 
 all-boards:
-	$(Q)@for f in `cd boards; ls` ; do "$(MAKE)" --no-print-directory BOARD=$$f drop-board || break 1; done
+	@for f in `cd boards; ls` ; do "$(MAKE)" --no-print-directory BOARD=$$f drop-board || break 1; done
 
 drop: all-boards drop-pkg
 

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ $(EXECUTABLE): $(OBJECTS)
 	-@arm-none-eabi-size $(BUILD_PATH)/$(NAME).elf | awk '{ s=$$1+$$2; print } END { print ""; print "Space left: " ($(BOOTLOADER_SIZE)-s) }'
 	@echo
 
-$(BUILD_PATH)/uf2_version.h: Makefile dirs
+$(BUILD_PATH)/uf2_version.h: Makefile | dirs
 	@echo "#define UF2_VERSION_BASE \"$(UF2_VERSION_BASE)\""> $@
 
 $(SELF_EXECUTABLE): $(SELF_OBJECTS)

--- a/boards/itsybitsy_m0/board_config.h
+++ b/boards/itsybitsy_m0/board_config.h
@@ -9,6 +9,10 @@
 #define INDEX_URL "http://adafru.it/3727"
 #define BOARD_ID "SAMD21G18A-ItsyBitsy-v0"
 
+// URL does not fit, even without INDEX.HTM
+#define USE_URL_IN_INFO 0
+#define USE_INDEX_HTM 0
+
 #define USB_VID 0x239A
 #define USB_PID 0x000F
 

--- a/boards/mini_sam_m0/board_config.h
+++ b/boards/mini_sam_m0/board_config.h
@@ -9,6 +9,10 @@
 #define INDEX_URL "https://minifigboards.com"
 #define BOARD_ID "SAMD21G18A-MiniSAMM0-v0"
 
+// URL does not fit, even without INDEX.HTM
+#define USE_URL_IN_INFO 0
+#define USE_INDEX_HTM 0
+
 #define USB_VID 0x1209
 #define USB_PID 0x7102
 

--- a/boards/stackrduino_m0_pro/board_config.h
+++ b/boards/stackrduino_m0_pro/board_config.h
@@ -7,6 +7,10 @@
 #define INDEX_URL "https://github.com/StackRduino/StackRduino_M0"
 #define BOARD_ID "SAMD21G18A-StackRduino-PRO"
 
+// URL does not fit, even without INDEX.HTM
+#define USE_URL_IN_INFO 0
+#define USE_INDEX_HTM 0
+
 #define USB_VID 0x1209
 #define USB_PID 0xE3E2
 

--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -41,14 +41,27 @@
 // needs to be more than ~4200 (to force FAT16)
 #define NUM_FAT_BLOCKS 16000
 
+// 8kB with NeoPixel or DotStar is a tight fit.
+#define SAMD21_MINIMIZE (defined(SAMD21) && (defined(BOARD_NEOPIXEL_PIN) || defined(BOARD_RGBLED_CLOCK_PIN)))
+
 // Logging to help debugging
 #define USE_LOGS 0
 // Check various conditions; best leave on
 #define USE_ASSERT 0 // 188 bytes
 // Enable reading flash via FAT files; otherwise drive will appear empty
 #define USE_FAT 1 // 272 bytes
-// Enable index.htm file on the drive
-#define USE_INDEX_HTM 1 // 132 bytes
+
+// Enable URL in INFO_UF2.TXT. Used for boards that are a very tight fit.
+#ifndef USE_URL_IN_INFO
+#define USE_URL_IN_INFO SAMD21_MINIMIZE
+#endif
+
+// Enable index.htm file on the drive.
+// 132 bytes
+#ifndef USE_INDEX_HTM
+#define USE_INDEX_HTM (!USE_URL_IN_INFO)
+#endif
+
 // Enable USB CDC (Communication Device Class; i.e., USB serial) monitor for Arduino style flashing
 #define USE_CDC 1 // 1264 bytes (plus terminal, see below)
 // Support the UART (real serial port, not USB)

--- a/src/cdc_enumerate.c
+++ b/src/cdc_enumerate.c
@@ -749,7 +749,7 @@ __attribute__((noinline))
 static void configureInterruptInOut(uint8_t ep) {
     USB->DEVICE.DeviceEndpoint[ep].EPCFG.reg =
         USB_DEVICE_EPCFG_EPTYPE0(4) | USB_DEVICE_EPCFG_EPTYPE1(4);
-    USB->DEVICE.DeviceEndpoint[ep].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSSET_BK0RDY;
+    USB->DEVICE.DeviceEndpoint[ep].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_BK0RDY;
     USB->DEVICE.DeviceEndpoint[ep].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_BK1RDY;
     usb_endpoint_table[ep].DeviceDescBank[0].PCKSIZE.bit.SIZE = 3;
     usb_endpoint_table[ep].DeviceDescBank[1].PCKSIZE.bit.SIZE = 3;

--- a/src/cdc_enumerate.c
+++ b/src/cdc_enumerate.c
@@ -744,6 +744,18 @@ static void configureInOut(uint8_t in_ep) {
     usb_endpoint_table[in_ep].DeviceDescBank[1].ADDR.reg = (uint32_t)&endpointCache[in_ep].buf;
 }
 
+#if USE_HID || USE_WEBUSB
+__attribute__((noinline))
+static void configureInterruptInOut(uint8_t ep) {
+    USB->DEVICE.DeviceEndpoint[ep].EPCFG.reg =
+        USB_DEVICE_EPCFG_EPTYPE0(4) | USB_DEVICE_EPCFG_EPTYPE1(4);
+    USB->DEVICE.DeviceEndpoint[ep].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSSET_BK0RDY;
+    USB->DEVICE.DeviceEndpoint[ep].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_BK1RDY;
+    usb_endpoint_table[ep].DeviceDescBank[0].PCKSIZE.bit.SIZE = 3;
+    usb_endpoint_table[ep].DeviceDescBank[1].PCKSIZE.bit.SIZE = 3;
+}
+#endif
+
 static uint16_t wLength;
 
 static void sendCtrl(const void *data, uint32_t len) { USB_Write(data, MIN(len, wLength), 0); }
@@ -865,25 +877,11 @@ void AT91F_CDC_Enumerate() {
         configureInOut(USB_EP_MSC_IN);
 
 #if USE_HID
-        /* Configure INTERRUPT IN/OUT endpoint for HID interface*/
-        USB->DEVICE.DeviceEndpoint[USB_EP_HID].EPCFG.reg =
-            USB_DEVICE_EPCFG_EPTYPE0(4) | USB_DEVICE_EPCFG_EPTYPE1(4);
-
-        USB->DEVICE.DeviceEndpoint[USB_EP_HID].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSSET_BK0RDY;
-        USB->DEVICE.DeviceEndpoint[USB_EP_HID].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_BK1RDY;
-        usb_endpoint_table[USB_EP_HID].DeviceDescBank[0].PCKSIZE.bit.SIZE = 3;
-        usb_endpoint_table[USB_EP_HID].DeviceDescBank[1].PCKSIZE.bit.SIZE = 3;
+        configureInterruptInOut(USB_EP_HID);
 #endif
 
 #if USE_WEBUSB
-        /* Configure INTERRUPT IN/OUT endpoint for HID interface*/
-        USB->DEVICE.DeviceEndpoint[USB_EP_WEB].EPCFG.reg =
-            USB_DEVICE_EPCFG_EPTYPE0(4) | USB_DEVICE_EPCFG_EPTYPE1(4);
-
-        USB->DEVICE.DeviceEndpoint[USB_EP_WEB].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSSET_BK0RDY;
-        USB->DEVICE.DeviceEndpoint[USB_EP_WEB].EPSTATUSCLR.reg = USB_DEVICE_EPSTATUSCLR_BK1RDY;
-        usb_endpoint_table[USB_EP_WEB].DeviceDescBank[0].PCKSIZE.bit.SIZE = 3;
-        usb_endpoint_table[USB_EP_WEB].DeviceDescBank[1].PCKSIZE.bit.SIZE = 3;
+        configureInterruptInOut(USB_EP_WEB);
 #endif
 
         break;

--- a/src/fat.c
+++ b/src/fat.c
@@ -57,7 +57,11 @@ struct TextFile {
 const char infoUf2File[] = //
     "UF2 Bootloader " UF2_VERSION "\r\n"
     "Model: " PRODUCT_NAME "\r\n"
-    "Board-ID: " BOARD_ID "\r\n";
+    "Board-ID: " BOARD_ID "\r\n"
+    #if USE_URL_IN_INFO
+    INDEX_URL "\r\n"
+    #endif
+    ;
 
 #if USE_FAT
 #if USE_INDEX_HTM

--- a/src/msc.c
+++ b/src/msc.c
@@ -74,9 +74,12 @@
 #define  LSB(u16)   (((uint8_t  *)&(u16))[0]) //!< Least significant byte of \a u16.
 
 bool mscReset = false;
+//! True when a failed Data-In command has stalled Bulk-IN and must send CSW later.
+static bool udi_msc_csw_pending;
 
 void msc_reset(void) {
     mscReset = true;
+    udi_msc_csw_pending = false;
     reset_ep(USB_EP_MSC_IN);
     reset_ep(USB_EP_MSC_OUT);
 }
@@ -145,6 +148,8 @@ static void udi_msc_csw_process(void);
  * or UDD callback when endpoint halt is cleared
  */
 void udi_msc_csw_send(void);
+static bool udi_msc_csw_ready_to_send(void);
+static void udi_msc_command_invalid(void);
 
 /**
  * \name Routines manage sense data
@@ -318,6 +323,14 @@ void process_msc(void) {
     process_hid();
 #endif
 
+    if (udi_msc_csw_pending) {
+        if (!udi_msc_csw_ready_to_send())
+            return;
+        udi_msc_csw_pending = false;
+        udi_msc_csw_process();
+        return;
+    }
+
     if (!try_read_cbw(&udi_msc_cbw, USB_EP_MSC_OUT, false))
         return; // no data
 
@@ -381,8 +394,7 @@ void process_msc(void) {
 
     default:
         logval("Invalid MSC command", udi_msc_cbw.CDB[0]);
-        udi_msc_sense_command_invalid();
-        udi_msc_csw_process();
+        udi_msc_command_invalid();
         break;
     }
 }
@@ -438,28 +450,6 @@ static void udi_msc_data_send(uint8_t *buffer, uint8_t buf_size) {
 //------- Routines to process CSW packet
 
 static void udi_msc_csw_process(void) {
-    if (0 != udi_msc_csw.dCSWDataResidue) {
-        logval("left-over residue", udi_msc_csw.dCSWDataResidue);
-
-        /*
-        uint8_t buf[64] = {0};
-        while (udi_msc_csw.dCSWDataResidue > 0) {
-            size_t len = min(udi_msc_csw.dCSWDataResidue, 64);
-            USB_Write((void *)buf, len, USB_EP_MSC_IN);
-            udi_msc_csw.dCSWDataResidue -= len;
-        }
-        */
-
-        /*
-        // Residue not NULL
-        // then STALL next request from USB host on corresponding endpoint
-        if (udi_msc_cbw.bmCBWFlags & USB_CBW_DIRECTION_IN)
-            udd_ep_set_halt(USB_EP_MSC_IN);
-        else
-            udd_ep_set_halt(USB_EP_MSC_OUT);
-            */
-    }
-
     // Prepare and send CSW
     udi_msc_csw.dCSWTag = udi_msc_cbw.dCBWTag;
     udi_msc_csw.dCSWDataResidue = cpu_to_le32(udi_msc_csw.dCSWDataResidue);
@@ -467,6 +457,24 @@ static void udi_msc_csw_process(void) {
 }
 
 void udi_msc_csw_send(void) { USB_Write((void *)&udi_msc_csw, sizeof(udi_msc_csw), USB_EP_MSC_IN); }
+
+static bool udi_msc_csw_ready_to_send(void) {
+    return !(USB->DEVICE.DeviceEndpoint[USB_EP_MSC_IN].EPSTATUS.reg &
+             USB_DEVICE_EPSTATUSSET_STALLRQ1);
+}
+
+static void udi_msc_command_invalid(void) {
+    udi_msc_sense_command_invalid();
+
+    if ((udi_msc_csw.dCSWDataResidue != 0) &&
+        (udi_msc_cbw.bmCBWFlags & USB_CBW_DIRECTION_IN)) {
+        udi_msc_csw_pending = true;
+        udd_ep_set_halt(USB_EP_MSC_IN);
+        return;
+    }
+
+    udi_msc_csw_process();
+}
 
 //---------------------------------------------
 //------- Routines manage sense data

--- a/src/msc.c
+++ b/src/msc.c
@@ -458,18 +458,26 @@ static void udi_msc_csw_process(void) {
 
 void udi_msc_csw_send(void) { USB_Write((void *)&udi_msc_csw, sizeof(udi_msc_csw), USB_EP_MSC_IN); }
 
+// CSW is always sent on EP_MSC_IN, but USB_Write is blocking — so for both
+// Hi> and Ho> failures we must defer the CSW until the host has cleared
+// the relevant pipe halt. Otherwise, the main loop is stuck inside USB_Write
+// and we can't process the host's CLEAR_FEATURE SETUP, deadlocking recovery.
+// We check both directions: only one is stalled at a time, but checking both
+// means the predicate doesn't need to know which.
 static bool udi_msc_csw_ready_to_send(void) {
     return !(USB->DEVICE.DeviceEndpoint[USB_EP_MSC_IN].EPSTATUS.reg &
-             USB_DEVICE_EPSTATUSSET_STALLRQ1);
+             USB_DEVICE_EPSTATUSSET_STALLRQ1) &&
+           !(USB->DEVICE.DeviceEndpoint[USB_EP_MSC_OUT].EPSTATUS.reg &
+             USB_DEVICE_EPSTATUSSET_STALLRQ0);
 }
 
 static void udi_msc_command_invalid(void) {
     udi_msc_sense_command_invalid();
 
-    if ((udi_msc_csw.dCSWDataResidue != 0) &&
-        (udi_msc_cbw.bmCBWFlags & USB_CBW_DIRECTION_IN)) {
+    if (udi_msc_csw.dCSWDataResidue != 0) {
         udi_msc_csw_pending = true;
-        udd_ep_set_halt(USB_EP_MSC_IN);
+        udd_ep_set_halt((udi_msc_cbw.bmCBWFlags & USB_CBW_DIRECTION_IN)
+                        ? USB_EP_MSC_IN : USB_EP_MSC_OUT);
         return;
     }
 

--- a/src/msc.c
+++ b/src/msc.c
@@ -74,7 +74,9 @@
 #define  LSB(u16)   (((uint8_t  *)&(u16))[0]) //!< Least significant byte of \a u16.
 
 bool mscReset = false;
-//! True when a failed Data-In command has stalled Bulk-IN and must send CSW later.
+//! True when an invalid command with nonzero residue has stalled a bulk endpoint
+//! and the CSW must be sent later; the stall may be on Bulk-IN or Bulk-OUT
+//! depending on the CBW direction.
 static bool udi_msc_csw_pending;
 
 void msc_reset(void) {


### PR DESCRIPTION
- Fixes #230.

See that issue for details about this bug.

- Add proper handling of residue for error responses. This fix was developed with the help of LLM's.
- The additional code needed caused a number of boards to overflow. To get around this problem, `USE_INDEX_HTM` was turned off on those boards. To ameliorate the loss of the board URL, a new functionality `USE_URL_IN_INFO` was added. It appends the board URL as the last line in the `INFO_UF2.TXT` file.
- A number of trials were done of other possible ways to save a few bytes. Two different LLM's offered suggestions and I tried some things I thought of myself as well. Many saved little or nothing. I tried `-flto` but it caused severe linking problems due to missing code, and the actual code saved by LTO was either nothing or vanishingly small.
- The `lib/uf2` submodule was updated to latest to incorporate fixes and modernization in Python code. This prevents some warnings.
- The `Makefile` was made a lot quieter by suppressing the echoing of most command lines. `VERBOSE=1` will show command lines.

One possible further way to save a couple of hundred bytes is to incorporate https://github.com/microsoft/uf2-samdx1/pull/48, a PR from 2018 (!) that was never tested on WS2812 or APA102 RGB LEDs.

NOTE: arm-none-eabi-gcc 15.2Rel1 regressed from previous versions, and produces noticeably larger code. So build with 14.3Rel1. That and 14.2Rel1 give the best size reduction on `-Os`.